### PR TITLE
Fix for Donator Flag

### DIFF
--- a/cogs/AMP_server_cog.py
+++ b/cogs/AMP_server_cog.py
@@ -344,7 +344,7 @@ class AMP_Server(commands.Cog):
 
         amp_server = await self.uBot._serverCheck(context, server, False)
         if amp_server: 
-            self.DB.GetServer(InstanceID= amp_server.InstanceID).Donator = {flag.value if type(flag) == Choice else flag}
+            self.DB.GetServer(InstanceID= amp_server.InstanceID).Donator = flag.value
             amp_server._setDBattr() #This will update the AMPConsole Attributes
             return await context.send(f"Set **{amp_server.InstanceName}** Donator Only to `{flag.name if type(flag) == Choice else bool(flag)}`", ephemeral= True, delete_after= self._client.Message_Timeout)
         


### PR DESCRIPTION
There is a bug currently that the Donator Only shows on any server that the setting is edited for. The `/server setting donator` command sets it to 1 in the database no matter what is selected. I believe this is the correct way to fix it (worked in testing on my end, but I'm not a Python expert). I based this on the code used for the SQL update under the `hidden` command.